### PR TITLE
Fix weekend check

### DIFF
--- a/Downloads/TTC-Predictor/TTC-Predictor/ttc-dashboard/src/App.js
+++ b/Downloads/TTC-Predictor/TTC-Predictor/ttc-dashboard/src/App.js
@@ -36,7 +36,8 @@ const TTCDelayDashboard = () => {
     subway_line: "YU",
     temperature: 15,
     precipitation: 0,
-    is_weekend: new Date().getDay() >= 5,
+    // Weekend should only include Saturday (6) and Sunday (0)
+    is_weekend: [0, 6].includes(new Date().getDay()),
   });
 
   const stations = {


### PR DESCRIPTION
## Summary
- correct weekend calculation in React form

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461a0dc408832fa92eb2324e5a6bad